### PR TITLE
Try to fix icon url issue

### DIFF
--- a/src/routes/styles.scss
+++ b/src/routes/styles.scss
@@ -41,7 +41,7 @@ a.external::after {
 	width: 0.6em;
 	height: 0.6em;
 	margin-left: 0.25em;
-	background-image: url('icons/ext-link.svg');
+	background-image: url('./icons/ext-link.svg');
 	background-position: center;
 	background-repeat: no-repeat;
 	background-size: contain;


### PR DESCRIPTION
Try to fix the issue with the missing icon after Nitrex:
<img width="1849" alt="Screenshot 2023-02-19 at 7 14 49 PM" src="https://user-images.githubusercontent.com/35657654/219966994-5fd2f788-66c6-4e24-a373-61fad37a4478.png">

During development it looks like this:

<img width="1849" alt="Screenshot 2023-02-19 at 7 15 23 PM" src="https://user-images.githubusercontent.com/35657654/219967026-d8b5af4f-a600-4fb0-b191-6fa99ca620ac.png">

